### PR TITLE
feat: use full path to Gitlab group

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="MavenProjectsManager">
@@ -7,7 +8,7 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="temurin-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,13 @@ ARG PACKAGE
 ARG PACKAGE_DOT
 
 USER root
-RUN mkdir -p /opt/sonatype/nexus/system/${PACKAGE}/${PLUGIN_NAME}/${RELEASE_TAG}/
-COPY target/feature/feature.xml /opt/sonatype/nexus/system/${PACKAGE}/${PLUGIN_NAME}/${RELEASE_TAG}/${PLUGIN_NAME}-${RELEASE_TAG}-features.xml
-COPY pom.xml /opt/sonatype/nexus/system/${PACKAGE}/${PLUGIN_NAME}/${RELEASE_TAG}/${PLUGIN_NAME}-${RELEASE_TAG}.pom
-RUN echo '<?xml version="1.0" encoding="UTF-8"?><metadata><groupId>${PACKAGE_DOT}</groupId><artifactId>${PLUGIN_NAME}</artifactId><versioning><release>${RELEASE_TAG}</release><versions><version>${RELEASE_TAG}</version></versions><lastUpdated>20230130132608</lastUpdated></versioning></metadata>' > /opt/sonatype/nexus/system/${PACKAGE}/${PLUGIN_NAME}/maven-metadata-local.xml
-RUN echo "mvn\:${PACKAGE_DOT}/${PLUGIN_NAME}/${RELEASE_TAG} = 200" >> /opt/sonatype/nexus/etc/karaf/startup.properties
+# remove the comments of the following lines for using .jar instead of .kar
+#RUN mkdir -p /opt/sonatype/nexus/system/${PACKAGE}/${PLUGIN_NAME}/${RELEASE_TAG}/
+#COPY target/feature/feature.xml /opt/sonatype/nexus/system/${PACKAGE}/${PLUGIN_NAME}/${RELEASE_TAG}/${PLUGIN_NAME}-${RELEASE_TAG}-features.xml
+#COPY pom.xml /opt/sonatype/nexus/system/${PACKAGE}/${PLUGIN_NAME}/${RELEASE_TAG}/${PLUGIN_NAME}-${RELEASE_TAG}.pom
+#RUN echo '<?xml version="1.0" encoding="UTF-8"?><metadata><groupId>${PACKAGE_DOT}</groupId><artifactId>${PLUGIN_NAME}</artifactId><versioning><release>${RELEASE_TAG}</release><versions><version>${RELEASE_TAG}</version></versions><lastUpdated>20230130132608</lastUpdated></versioning></metadata>' > /opt/sonatype/nexus/system/${PACKAGE}/${PLUGIN_NAME}/maven-metadata-local.xml
+#RUN echo "mvn\:${PACKAGE_DOT}/${PLUGIN_NAME}/${RELEASE_TAG} = 200" >> /opt/sonatype/nexus/etc/karaf/startup.properties
 
-ENV INSTALL4J_ADD_VM_PARAMS="-Xms2703m -Xmx2703m -XX:MaxDirectMemorySize=2703m -Djava.util.prefs.userRoot=${NEXUS_DATA}/javaprefs -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8082"
+ENV INSTALL4J_ADD_VM_PARAMS="-Xms2703m -Xmx2703m -XX:MaxDirectMemorySize=2703m -Djava.util.prefs.userRoot=${NEXUS_DATA}/javaprefs -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:8082"
 
 USER nexus

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM sonatype/nexus3:3.67.0
+FROM sonatype/nexus3:3.75.1
 
 ARG RELEASE_TAG
 ARG PLUGIN_NAME

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,9 +11,17 @@ services:
     ports:
       - 8081:8081
       - 8082:8082
+      - 5000:5000
     volumes:
       - /nexus-data
       - ./gitlabpatauth.properties:/opt/sonatype/nexus/etc/gitlabpatauth.properties
-      - ./target/${ARTIFACT}-${VERSION}.jar:/opt/sonatype/nexus/system/${PACKAGE}/${ARTIFACT}/${VERSION}/${ARTIFACT}-${VERSION}.jar
-      - ./target/feature/feature.xml:/opt/sonatype/nexus/system/${PACKAGE}/${ARTIFACT}/${VERSION}/${ARTIFACT}-${VERSION}-features.xml
-      - ./pom.xml:/opt/sonatype/nexus/system/${PACKAGE}/${ARTIFACT}/${VERSION}/pom.xml
+      - ./etc/logback:/opt/sonatype/nexus/etc/logback:ro
+#      - ./etc/nexus-default.properties:/opt/sonatype/nexus/etc/nexus-default.properties:ro
+
+      # jar related
+#      - ./target/${ARTIFACT}-${VERSION}.jar:/opt/sonatype/nexus/system/${PACKAGE}/${ARTIFACT}/${VERSION}/${ARTIFACT}-${VERSION}.jar
+#      - ./target/feature/feature.xml:/opt/sonatype/nexus/system/${PACKAGE}/${ARTIFACT}/${VERSION}/${ARTIFACT}-${VERSION}-features.xml
+#      - ./pom.xml:/opt/sonatype/nexus/system/${PACKAGE}/${ARTIFACT}/${VERSION}/pom.xml
+
+      # kar related
+      - ./target/${ARTIFACT}-${VERSION}-bundle.kar:/opt/sonatype/nexus/deploy/${ARTIFACT}-${VERSION}-bundle.kar

--- a/gitlabpatauth.properties.README
+++ b/gitlabpatauth.properties.README
@@ -21,3 +21,10 @@ gitlab.group-minimal-access-level=10
 #   Null value - map all user groups to roles
 #   Empty value - do not map any group
 #gitlab.groups-mapped=my-fancy-group
+
+# Enable or disable username validation on login. GitLab allows token login without specifying
+# the username. If the setting is true it mimics GitLab's behavior.
+# Default - false
+#   true - validate if specified username matches the one from the token
+#   false - allow any username and token combination (token needs to be still valid)
+#gitlab.skip-username-validation=false

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.sonatype.nexus.plugins</groupId>
         <artifactId>nexus-plugins</artifactId>
-        <version>3.42.0-01</version>
+        <version>3.75.0-06</version>
     </parent>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -28,8 +28,8 @@
 
     <properties>
         <dryRun>true</dryRun>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jersey.version>2.39.1</jersey.version>
         <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
@@ -82,9 +82,21 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
+                <dependencies>
+                    <!--
+                      To support building nexus-public, we have to select the last version of groovy-eclipse-batch available
+                      in Maven Central. This comes with a downside, as this compiler won't support the use of the parallel
+                      build options in maven (e.g. `-T 1C`).
+                     -->
+                    <dependency>
+                        <groupId>org.codehaus.groovy</groupId>
+                        <artifactId>groovy-eclipse-batch</artifactId>
+                        <version>3.0.8-01</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.apache.karaf.tooling</groupId>
@@ -104,16 +116,11 @@
                         </Bundle-License>
                         <Bundle-DocURL>https://github.com/elwin013/nexus3-gitlab-patauth-plugin</Bundle-DocURL>
                         <Bundle-Version>${project.version}</Bundle-Version>
-                        <Import-Package>*</Import-Package>
-                        <Embed-Dependency>
-                            httpclient;scope=compile
-                        </Embed-Dependency>
-                        <Export-Package>
-                        </Export-Package>
+                        <Embed-Dependency>*;scope=compile|runtime;inline=true</Embed-Dependency>
+                        <Export-Package>com.elwin013.gitlabpatauth</Export-Package>
                     </instructions>
                 </configuration>
             </plugin>
-
         </plugins>
     </build>
 

--- a/src/main/java/com/elwin013/gitlabpatauth/GitLabPatAuthFakeUserManager.java
+++ b/src/main/java/com/elwin013/gitlabpatauth/GitLabPatAuthFakeUserManager.java
@@ -70,6 +70,12 @@ public class GitLabPatAuthFakeUserManager extends AbstractReadOnlyUserManager {
         return this.getUser(userId);
     }
 
+    @Override
+    public boolean isConfigured() {
+        return true;
+    }
+
+
     private User toUser(String userId, CUser cUser) {
         User user = new User();
         user.setUserId(cUser.getId());

--- a/src/main/java/com/elwin013/gitlabpatauth/GitlabApiWrapper.java
+++ b/src/main/java/com/elwin013/gitlabpatauth/GitlabApiWrapper.java
@@ -28,6 +28,7 @@ public class GitlabApiWrapper {
     private final List<String> groupsAllowed;
     private final List<String> mappedGroups;
     private final String gitlabUrl;
+    private final Boolean skipUsernameValidation;
 
     @Inject
     public GitlabApiWrapper(GitlabPatAuthConfig config) {
@@ -35,6 +36,7 @@ public class GitlabApiWrapper {
         this.minimalAccessLevel = config.getMinimalAccessLevel();
         this.groupsAllowed = config.getGroupsAllowed();
         this.mappedGroups = config.getMappedGroups();
+        this.skipUsernameValidation = config.skipUsernameValidation();
         this.principalCache = CacheBuilder.newBuilder()
                 .expireAfterWrite(config.getLoginCacheTtl())
                 .build();
@@ -49,7 +51,8 @@ public class GitlabApiWrapper {
         try (GitlabApi api = new GitlabApi(gitlabUrl, personalAccessToken)) {
             User currentUser = api.getUserInfo();
 
-            if (!Objects.equals(StringUtils.lowerCase(currentUser.getUsername()), StringUtils.lowerCase(username))) {
+            boolean usernameMatches = Objects.equals(StringUtils.lowerCase(currentUser.getUsername()), StringUtils.lowerCase(username));
+            if (!skipUsernameValidation && !usernameMatches) {
                 return null;
             }
             Set<Group> groups = api.getUserGroups(minimalAccessLevel);

--- a/src/main/java/com/elwin013/gitlabpatauth/GitlabApiWrapper.java
+++ b/src/main/java/com/elwin013/gitlabpatauth/GitlabApiWrapper.java
@@ -5,6 +5,7 @@ import com.elwin013.gitlabpatauth.api.model.Group;
 import com.elwin013.gitlabpatauth.api.model.User;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,7 +49,7 @@ public class GitlabApiWrapper {
         try (GitlabApi api = new GitlabApi(gitlabUrl, personalAccessToken)) {
             User currentUser = api.getUserInfo();
 
-            if (!Objects.equals(currentUser.getUsername(), username)) {
+            if (!Objects.equals(StringUtils.lowerCase(currentUser.getUsername()), StringUtils.lowerCase(username))) {
                 return null;
             }
             Set<Group> groups = api.getUserGroups(minimalAccessLevel);

--- a/src/main/java/com/elwin013/gitlabpatauth/GitlabPatAuthConfig.java
+++ b/src/main/java/com/elwin013/gitlabpatauth/GitlabPatAuthConfig.java
@@ -12,6 +12,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 
@@ -72,7 +73,11 @@ public class GitlabPatAuthConfig {
     }
 
     public List<String> getGroupsAllowed() {
-        return Arrays.asList(props.getProperty(GROUPS_ALLOWED_KEY, "").split(","));
+        String allowedGroups = props.getProperty(GROUPS_ALLOWED_KEY, null);
+        if (allowedGroups == null) {
+            return Collections.emptyList();
+        }
+        return Arrays.asList(allowedGroups.split(","));
     }
 
     @SuppressWarnings("java:S1168")

--- a/src/main/java/com/elwin013/gitlabpatauth/GitlabPatAuthConfig.java
+++ b/src/main/java/com/elwin013/gitlabpatauth/GitlabPatAuthConfig.java
@@ -1,6 +1,7 @@
 package com.elwin013.gitlabpatauth;
 
 import com.google.inject.Singleton;
+import org.apache.commons.lang3.BooleanUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,12 +25,15 @@ public class GitlabPatAuthConfig {
     private static final String DEFAULT_GITLAB_URL = "https://gitlab.com";
     private static final String DEFAULT_GITLAB_LOGIN_CACHE_TTL = "1";
     private static final String DEFAULT_GROUP_MINIMAL_ACCESS_LEVEL_KEY = "10"; // Guest
+    private static final Boolean DEFAULT_SKIP_USERNAME_VALIDATION = false;
 
     private static final String GITLAB_URL_KEY = "gitlab.url";
     private static final String LOGIN_CACHE_TTL_KEY = "gitlab.cache-ttl-minutes";
     private static final String GROUP_MINIMAL_ACCESS_LEVEL_KEY = "gitlab.group-minimal-access-level";
     private static final String GROUPS_ALLOWED_KEY = "gitlab.groups-allowed";
     private static final String GROUPS_MAPPED_KEY = "gitlab.groups-mapped";
+    private static final String SKIP_USERNAME_VALIDATION = "gitlab.skip-username-validation";
+
 
     private final Properties props;
 
@@ -87,6 +91,15 @@ public class GitlabPatAuthConfig {
             return null;
         } else {
             return Arrays.asList(prop.split(","));
+        }
+    }
+
+    public Boolean skipUsernameValidation() {
+        String prop = props.getProperty(SKIP_USERNAME_VALIDATION);
+        if (prop == null) {
+            return false;
+        } else {
+            return BooleanUtils.toBoolean(prop);
         }
     }
 }

--- a/src/main/java/com/elwin013/gitlabpatauth/api/model/Group.java
+++ b/src/main/java/com/elwin013/gitlabpatauth/api/model/Group.java
@@ -1,6 +1,7 @@
 package com.elwin013.gitlabpatauth.api.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Objects;
 
@@ -26,6 +27,7 @@ public class Group {
         this.name = name;
     }
 
+    @JsonProperty("full_path")
     public String getPath() {
         return path;
     }


### PR DESCRIPTION
While playing around with the plugin I stumbled upon some issues. Hence, this MR proposes the following changes:

1. Use the full path instead of just the path for mapping groups because only the full path identifies a Gitlab group uniquely
2. The username should be case insensitive to prevent user confusion and to comply with the behaviour of other tools (if not all other)
3. Handle allowed groups as described in the properties file: An empty list should map all groups.
4. Bump Nexus version in Dockerfile to `3.75.1` (and test the plugin with that version)